### PR TITLE
fix: 🐛 products details modifications

### DIFF
--- a/apps/rose/src/app/features/pages/details/components/product-details/product-details.component.html
+++ b/apps/rose/src/app/features/pages/details/components/product-details/product-details.component.html
@@ -13,14 +13,14 @@
         </div>
         <div class="others flex justify-content-center align-items-center gap-3">
           @for (image of productDetails().images; track $index) {
-          <div class="image flex justify-content-center cursor-pointer flex-wrap" (click)="onThumbnailClick(image)">
+          <div class="image flex justify-content-center cursor-pointer flex-wrap" [ngClass]="{ 'active-thumbnail': currentImage() === image }" (click)="onThumbnailClick(image)">
             <img class="object-cover" width="91" height="110" [ngSrc]="image" [alt]="productDetails().slug" />
           </div>
           }
         </div>
       </div>
     </div>
-    <div class="md:col-7 col-12 border">
+    <div class="md:col-6 col-12 border">
       <div class="product-info h-full flex flex-column justify-content-between">
         <div>
           <h2 class="font-semibold mb-1 mt-0">{{ productDetails().title }}</h2>
@@ -47,7 +47,7 @@
           <button class="submit-btn wish cursor-pointer flex-grow-0 w-fit capitalize">
             <i class="pi  pi-heart"></i>
           </button>
-          <button class="submit-btn cursor-pointer flex-grow-1 capitalize">
+          <button class="submit-btn cart cursor-pointer flex-grow-1 capitalize">
             <i class="pi pi-shopping-cart mr-1"></i>
             add to cart
           </button>

--- a/apps/rose/src/app/features/pages/details/components/product-details/product-details.component.scss
+++ b/apps/rose/src/app/features/pages/details/components/product-details/product-details.component.scss
@@ -98,6 +98,15 @@
         background-color: #F4F4F5;
         color: black;
       }
+
+      .cart{
+        background-color: var(--btn-shared-background);
+        color: var(--btn-shared-color);
+        transition: all 0.3s;
+      }
+      .cart:hover{
+        background-color: var( --btn-shared-background-hover);
+      }
     }
   }
 
@@ -123,3 +132,21 @@
   border-bottom-right-radius: 12px;
   border-bottom-left-radius: 12px;
 }
+
+
+.image {
+  border: 2.5px solid transparent;
+  border-radius: 15px;
+  transition: border 0.3s, transform 0.2s;
+
+  &:hover {
+    border-color: #ccc;
+    transform: scale(1.05);
+  }
+
+  &.active-thumbnail {
+    border-color: var(--preview-color); 
+    box-shadow: 0 0 8px var(--preview-color)(0, 123, 255, 0.4);
+  }
+}
+

--- a/apps/rose/src/app/features/pages/details/components/product-details/product-details.component.ts
+++ b/apps/rose/src/app/features/pages/details/components/product-details/product-details.component.ts
@@ -1,5 +1,7 @@
 import { Component,input, signal, effect } from '@angular/core';
 import { NgOptimizedImage } from '@angular/common';
+import { NgClass } from '@angular/common';
+
 //interfaces
 import { Product } from '@rose/core_interfaces/carditem.interface';
 // PrimeNG
@@ -8,7 +10,7 @@ import { DialogModule } from 'primeng/dialog';
 @Component({
   selector: 'app-product-details',
   standalone: true,
-  imports: [ NgOptimizedImage, DialogModule],
+  imports: [ NgOptimizedImage, DialogModule, NgClass ],
   templateUrl: './product-details.component.html',
   styleUrl: './product-details.component.scss'
 })

--- a/apps/rose/src/app/features/pages/details/components/product-review/review-form/review-form.component.html
+++ b/apps/rose/src/app/features/pages/details/components/product-review/review-form/review-form.component.html
@@ -16,6 +16,6 @@
         type="text" rows="4"
         class="text-base surface-overlay p-2 border-1 border-solid border-round appearance-none outline-none  w-full"></textarea>
     </div>
-    <button type="submit" class="btn submit-btn font-semibold capitalize cursor-pointer">{{ 'Details.addReview' | translate }}</button>
+    <button type="submit" class="btn review submit-btn font-semibold capitalize cursor-pointer">{{ 'Details.addReview' | translate }}</button>
   </div>
 </form>

--- a/apps/rose/src/app/features/pages/details/components/product-review/review-form/review-form.component.scss
+++ b/apps/rose/src/app/features/pages/details/components/product-review/review-form/review-form.component.scss
@@ -21,4 +21,13 @@
       text-transform: capitalize;
     }
   }
+
+  .review{
+        background-color: var(--btn-shared-background);
+        color: var(--btn-shared-color);
+        transition: all 0.3s;
+      }
+      .review:hover{
+        background-color: var( --btn-shared-background-hover);
+      }
 }

--- a/apps/rose/src/app/features/pages/details/components/related-products/related-products.component.html
+++ b/apps/rose/src/app/features/pages/details/components/related-products/related-products.component.html
@@ -1,4 +1,4 @@
-<section>
+<section class="mb-8">
   <!-- Title -->
   <div class="p-relative d-inline-block details-title-wrapper">
     <h2 id="details-heading" class="details-title" itemprop="name">

--- a/apps/rose/src/app/features/pages/details/details.component.ts
+++ b/apps/rose/src/app/features/pages/details/details.component.ts
@@ -1,13 +1,16 @@
 
 import { Component, inject, OnInit,OnDestroy } from "@angular/core";
 import { CommonModule } from "@angular/common";
-import { ProductReviewComponent } from "./components/product-review/product-review.component";
 import { ActivatedRoute } from "@angular/router";
 import { Subscription } from "rxjs";
-import { ProductsService } from "../../../shared/services/products/products.service";
-import { Product } from "../../../core/interfaces/carditem.interface";
+//Interfaces
+import { Product } from "@rose/core_interfaces/carditem.interface";
+//Components
 import { ProductDetailsComponent } from "./components/product-details/product-details.component";
 import { RelatedProductsComponent } from "./components/related-products/related-products.component";
+import { ProductReviewComponent } from "./components/product-review/product-review.component";
+//Shared Services
+import { ProductsService } from "@rose/shared_services/products/products.service";
 
 @Component({
   selector: "app-details",
@@ -24,14 +27,21 @@ export class DetailsComponent implements OnInit, OnDestroy {
   productDetails:Product = {} as Product;
 
 
-  getProductId(){
-    this._activatedRoute.params.subscribe({
-      next:(params)=>{
-        this.productId=params['id'];
-        this.getProductDetails()
-      }
-    })
-  }
+ getProductId() {
+  this._activatedRoute.params.subscribe({
+    next: (params) => {
+      setTimeout(() => {
+        document.documentElement.scrollTop = 0;
+        document.body.scrollTop = 0;
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+      }, 0);
+
+      this.productId = params['id'];
+      this.getProductDetails();
+    }
+  });
+}
+
 
 
   getProductDetails(){

--- a/apps/rose/src/app/shared/services/products/products.service.ts
+++ b/apps/rose/src/app/shared/services/products/products.service.ts
@@ -50,4 +50,5 @@ export class ProductsService {
   getSpecificProduct(id: string): Observable<ProductDetailsRes> { //get specific product by id
     return this.httpClient.get<ProductDetailsRes>(`${EndPoint.PRODUCTS}/${id}`).pipe(shareReplay(1));
   }
+  
 }


### PR DESCRIPTION
added bottom margins
fixed product detail cut off
when a new product is selected in related products , it returns to the beginning of the page
fixed button colors
added over and active for the thumbnail images
